### PR TITLE
fix: configuring hugo modules config on the cd workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
+
+      - name: Download Hugo modules
+        run: hugo mod download
 
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
Hugo modules/themes were not being downloaded correctly. This PR adds the 'Download Hugo Modules' step on the GH Actions workflow so that these modules are downloaded and configured.